### PR TITLE
Add **kwargs to localizer constructors

### DIFF
--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -36,7 +36,7 @@ class AbstractLocalizer(abc.ABC):
     def __init__(
         self, backend: AbstractSlurmBackend, transfer_bucket: typing.Optional[str] = None,
         common: bool = True, staging_dir: str = None, mount_path: str = None,
-        project: typing.Optional[str] = None,
+        project: typing.Optional[str] = None, **kwargs
     ):
         """
         Initializes the Localizer using the given transport.

--- a/canine/localization/local.py
+++ b/canine/localization/local.py
@@ -28,7 +28,7 @@ class BatchedLocalizer(AbstractLocalizer):
     def __init__(
         self, backend: AbstractSlurmBackend, transfer_bucket: typing.Optional[str] = None,
         common: bool = True, staging_dir: str = None, mount_path: str = None,
-        project : typing.Optional[str] = None
+        project : typing.Optional[str] = None, **kwargs
     ):
 
         """

--- a/canine/localization/nfs.py
+++ b/canine/localization/nfs.py
@@ -27,7 +27,7 @@ class NFSLocalizer(BatchedLocalizer):
     def __init__(
         self, backend: AbstractSlurmBackend, transfer_bucket: typing.Optional[str] = None,
         common: bool = True, staging_dir: str = None, mount_path: str = None,
-        project: typing.Optional[str] = None,
+        project: typing.Optional[str] = None, **kwargs
     ):
         """
         Initializes the Localizer using the given transport.

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -132,11 +132,9 @@ class Orchestrator(object):
         if self.localizer_args['strategy'] not in LOCALIZERS:
             raise ValueError("Unknown localization strategy '{}'".format(self.localizer_args))
         self._localizer_type = LOCALIZERS[self.localizer_args['strategy']]
-        self.localizer_args = {key:val for key,val in self.localizer_args.items() if key != 'strategy'}
         self.localizer_overrides = {}
         if 'overrides' in self.localizer_args:
             self.localizer_overrides = {**self.localizer_args['overrides']}
-            del self.localizer_args['overrides']
         self.raw_outputs = Orchestrator.stringify(config['outputs']) if 'outputs' in config else {}
         if len(self.raw_outputs) == 0:
             warnings.warn("No outputs declared", stacklevel=2)


### PR DESCRIPTION
IMO, this makes the Canine API more friendly because it lets us instantiate localizers with

```python
localizer(backend, **conf['localization'])
```

where `conf['localization']` is straight from the config dict