### PR TITLE
Allow functions to be run on output DF columns …

### DIFF
--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -154,6 +154,7 @@ class Orchestrator(object):
 
         #
         # outputs
+        self.output_map = {}
         if "outputs" in config:
             # process optional output postprocessing functions
             self.output_map = {}

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -157,7 +157,6 @@ class Orchestrator(object):
         self.output_map = {}
         if "outputs" in config:
             # process optional output postprocessing functions
-            self.output_map = {}
             for k, v in config["outputs"].items():
                 if type(v) == tuple and callable(v[1]):
                     self.output_map[k] = v[1]

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     package_data={
         '':[
             'backends/slurm-gcp/*',
-            'backends/slurm-gcp/scripts/*'
+            'backends/slurm-gcp/scripts/*',
             'backends/slurm-docker/src/*'
         ],
     },


### PR DESCRIPTION
Previously, the output dataframe could only contain filepaths. However, it is often useful to read in the contents of those files and store those in the DF instead. This allows us to do that (and apply any other callable to DF output columns).

Example syntax:
```python
outputs = {
  "foo" : "foo.txt",
  "bar" : "bar.jpg",
  "baz" : ("baz.txt", callable)
}
```

will results in the output dataframe column `baz` containing `callable` applied to `baz.txt`