### PR TITLE
Save output dataframe as HDF5, not Pickle

### DIFF
--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -535,7 +535,7 @@ class Orchestrator(object):
 
                     return np.count_nonzero(~fail_idx)
                 except (ValueError, OSError) as e:
-                    print("Cannot recover preexisting task outputs: " + e, file = sys.stderr)
+                    print("Cannot recover preexisting task outputs: " + str(e), file = sys.stderr)
                     print("Overwriting output and aborting job avoidance.", file = sys.stderr)
                     transport.rmtree(localizer.staging_dir)
                     transport.makedirs(localizer.staging_dir)

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -470,7 +470,7 @@ class Orchestrator(object):
             if transport.exists(df_path):
                 try:
                     # load in results and job spec dataframes
-                    with transport.open(df_path) as r:
+                    with transport.open(df_path, mode = "rb") as r:
                         r_df = pandas_read_hdf5_buffered(key = "results", buf = r)
                     js_df = pd.DataFrame.from_dict(self.job_spec, orient = "index").rename_axis(index = "_job_id")
 

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -412,6 +412,8 @@ class Orchestrator(object):
                     # that don't receive any transformation with transformed columns
                     df["outputs"] = df["outputs"].agg({ **self.output_map, **identity_map })
             except:
+                df = pd.DataFrame()
+                print("Error generating output dataframe; see stack trace for details.", file = sys.stderr)
                 traceback.print_exc()
 
 

--- a/canine/utils.py
+++ b/canine/utils.py
@@ -293,10 +293,11 @@ def pandas_read_hdf5_buffered(key: str, buf: io.BufferedReader) -> pd.DataFrame:
     """
 	Read a Pandas dataframe in HDF5 format from a buffer.
     """
-    return pd.HDFStore(
-      "/dev/zeros",
+    with pd.HDFStore(
+      "dummy_hdf5",
       mode = "r",
       driver = "H5FD_CORE",
       driver_core_backing_store = 0,
       driver_core_image = buf.read()
-    )[key]
+    ) as store:
+        return store[key]

--- a/canine/utils.py
+++ b/canine/utils.py
@@ -12,6 +12,7 @@ import google.auth
 import paramiko
 import shutil
 import time
+import pandas as pd
 
 class ArgumentHelper(dict):
     """
@@ -274,3 +275,28 @@ def gcp_hourly_cost(mtype: str, preemptible: bool = False, ssd_size: int = 0, hd
     )
 
 # rmtree_retry removed in favor of AbstractTransport.rmtree
+
+def pandas_write_hdf5_buffered(df: pd.DataFrame, key: str, buf: io.BufferedWriter):
+    """
+	Write a Pandas dataframe in HDF5 format to a buffer.
+    """
+    with pd.HDFStore(
+      "/dev/null",
+      mode = "w",
+      driver = "H5FD_CORE",
+      driver_core_backing_store = 0
+    ) as store:
+        store["results"] = df
+        buf.write(store._handle.get_file_image())
+
+def pandas_read_hdf5_buffered(key: str, buf: io.BufferedReader) -> pd.DataFrame:
+    """
+	Read a Pandas dataframe in HDF5 format from a buffer.
+    """
+    return pd.HDFStore(
+      "/dev/zeros",
+      mode = "r",
+      driver = "H5FD_CORE",
+      driver_core_backing_store = 0,
+      driver_core_image = buf.read()
+    )[key]

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ setup(
         'google-api-python-client>=1.7.11',
         'docker>=4.1.0',
         'psutil>=5.6.7',
-        'port-for>=0.4'
+        'port-for>=0.4',
+        'tables>=3.6.1'
     ],
     classifiers = [
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
I was having issues with reading Pickles from a buffer — as updated in ee641937, in order to accommodate multiple backends, the output Pickle is now read via a transport, rather than with a simple `pd.read_pickle("filename")` call.

HDF5 is more amenable to being read/written via buffers, so I've switched over.